### PR TITLE
Avoid NPE for schemas with default values but no type

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -2257,31 +2257,33 @@ public class OpenAPIDeserializer {
 
         //sets default value according to the schema type
         if(node.get("default")!= null) {
-            if(schema.getType().equals("array")) {
+            if("array".equals(schema.getType())) {
                 ArrayNode array = getArray("default", node, false, location, result);
                 if (array != null) {
                     schema.setDefault(array);
                 }
-            }else if(schema.getType().equals("string")) {
+            }else if("string".equals(schema.getType())) {
                 value = getString("default", node, false, location, result);
                 if (value != null) {
                     schema.setDefault(value);
                 }
-            }else if(schema.getType().equals("boolean")) {
+            }else if("boolean".equals(schema.getType())) {
                 bool = getBoolean("default", node, false, location, result);
                 if (bool != null) {
                     schema.setDefault(bool);
                 }
-            }else if(schema.getType().equals("object")) {
+            }else if("object".equals(schema.getType())) {
                 Object object = getObject("default", node, false, location, result);
                 if (object != null) {
                     schema.setDefault(object);
                 }
-            }else if(schema.getType().equals("number")) {
+            }else if("number".equals(schema.getType())) {
                 Integer number = getInteger("default", node, false, location, result);
                 if (number != null) {
                     schema.setDefault(number);
                 }
+            }else {
+                // Do something sensible here
             }
         }
 


### PR DESCRIPTION
This PR fixes a bug exposed by one of the IBM Cloud API definitions that has a schema with a description and default values but no type (it is an element of an `allOf` where another element gives the type value).

I wasn't quite sure what to for the last `else`, but I didn't want to hold up this fix until we figured out how to handle that.